### PR TITLE
Fix query parameters

### DIFF
--- a/aqua.ts
+++ b/aqua.ts
@@ -114,7 +114,7 @@ export default class Aqua {
 
             return {
                 ...queries,
-                [query.split("=")?.[0]]: query.split("=")?.[1]
+                [decodeURIComponent(query.split("=")?.[0])]: decodeURIComponent(query.split("=")?.[1].replace(/\+/g, " "))
             }
         }, {}) || {};
     }

--- a/tests/uptests.ts
+++ b/tests/uptests.ts
@@ -42,20 +42,13 @@ Deno.test("URL parameters working?", async () => {
     });
 });
 
-Deno.test("URL query parameters working?", async () => {
-    app.route("/search", "GET", (req) => {
-        if (req.query.q !== "foo bar") throw Error("URL query parameters don't seem to work");
-        if (req.query.withCharsThatNeedEscaping !== "$&") throw Error("URL query parameters don't seem to work");
-        if (req.query.missing !== undefined) throw Error("URL query parameters don't seem to work");
-        return "Thanks for the search!";
+Deno.test("URL query decoding working?", async () => {
+    app.get("/search", (req) => {
+        return JSON.stringify(req.query);
     });
 
-    const content = await request(`/search?q=foo+bar&withCharsThatNeedEscaping=%24%26`);
-    await new Promise((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, 250);
-    });
+    const content = await request("/search?q=foo+bar&withCharsThatNeedEscaping=%24%26");
+    if (content !== `{"q":"foo bar","withCharsThatNeedEscaping":"$&"}`) throw Error("URL query decoding doesn't seem to work");
 });
 
 Deno.test("Custom fallback handler working?", async () => {

--- a/tests/uptests.ts
+++ b/tests/uptests.ts
@@ -42,6 +42,22 @@ Deno.test("URL parameters working?", async () => {
     });
 });
 
+Deno.test("URL query parameters working?", async () => {
+    app.route("/search", "GET", (req) => {
+        if (req.query.q !== "foo bar") throw Error("URL query parameters don't seem to work");
+        if (req.query.withCharsThatNeedEscaping !== "$&") throw Error("URL query parameters don't seem to work");
+        if (req.query.missing !== undefined) throw Error("URL query parameters don't seem to work");
+        return "Thanks for the search!";
+    });
+
+    const content = await request(`/search?q=foo+bar&withCharsThatNeedEscaping=%24%26`);
+    await new Promise((resolve) => {
+        setTimeout(() => {
+            resolve();
+        }, 250);
+    });
+});
+
 Deno.test("Custom fallback handler working?", async () => {
     app.provideFallback((req) => "Nothing to see here");
 


### PR DESCRIPTION
So that
1. Any '+'s are swapped for spaces when parsing query parameters
2. Any encoded characters are decoded