### PR TITLE
Missing "/" when reading file for the "serve" method

### DIFF
--- a/aqua.ts
+++ b/aqua.ts
@@ -416,7 +416,7 @@ export default class Aqua {
     try {
       return {
         headers: contentType ? { "Content-Type": contentType } : undefined,
-        content: await Deno.readFile(folder + resourcePath),
+        content: await Deno.readFile(`${folder}/${resourcePath}`),
       };
     } catch {
       return await this.getFallbackHandlerResponse(


### PR DESCRIPTION
Adding the missing "/" when reading the file from the system

fixes #93 